### PR TITLE
Change accessor level

### DIFF
--- a/src/main/java/com/stablekernel/standardlib/SingleFragmentActivity.java
+++ b/src/main/java/com/stablekernel/standardlib/SingleFragmentActivity.java
@@ -16,7 +16,7 @@ public class SingleFragmentActivity extends AppCompatActivity {
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         if (traceLog) Log.d("TRACE", "--> SingleFragmentActivity.onCreate()");
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_single_fragment);


### PR DESCRIPTION
This method shouldn't be public. It should match the accessor level of the base Activity class